### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/laxmanverma02/4ca59386-3cc2-4e9c-8b67-4cce9c9c7431/5bbe20b7-70e5-4e9d-bfb7-eda66cd2d697/_apis/work/boardbadge/797e7bde-b2df-4fe9-b1c9-e84f4b505c7c)](https://dev.azure.com/laxmanverma02/4ca59386-3cc2-4e9c-8b67-4cce9c9c7431/_boards/board/t/5bbe20b7-70e5-4e9d-bfb7-eda66cd2d697/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/laxmanverma02/4ca59386-3cc2-4e9c-8b67-4cce9c9c7431/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.